### PR TITLE
Move logic to aipl/ops/op_take

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       run: aipl -h
 
     - name: Run pytests
-      run: pytest .
+      run: pytest aipl/ops/*.py
 
     - name: Run aipl tests
       run: |

--- a/aipl/ops/conftest.py
+++ b/aipl/ops/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from aipl import AIPLInterpreter
+
+@pytest.fixture()
+def aipl():
+    r = AIPLInterpreter(debug=True)
+    return r

--- a/aipl/ops/op_func.py
+++ b/aipl/ops/op_func.py
@@ -17,12 +17,6 @@ def op_group(aipl, t:Table):
         yield dict(key=k, items=ret)
 
 
-@defop('take', 1.5, 1.5)
-def op_take(aipl, t:Table, n=1):
-    ret = copy(t)
-    ret.rows = t.rows[:n]
-    return ret
-
 @defop('unravel', 2, 1.5)
 def op_unravel(aipl, v:Table) -> Table:
     ret = Table()

--- a/aipl/ops/op_take.py
+++ b/aipl/ops/op_take.py
@@ -1,0 +1,21 @@
+'''
+!take `n` returns a copy of an input `Table` with only the first `n` rows.
+'''
+
+from copy import copy
+
+from aipl import defop
+from aipl.table import Table
+
+@defop('take', 1.5, 1.5)
+def op_take(aipl, t:Table, n=1) -> Table:
+    'Return a table with first n rows of `t`'
+    ret = copy(t)
+    ret.rows = t.rows[:n]
+    return ret
+
+def test_take(aipl):
+    r = aipl.run('!take 2', '1 2 3', '4 5 6', '7 8 9')
+    assert len(r.rows) == 2
+    assert r[0] == '1 2 3'
+    assert r[1] == '4 5 6'

--- a/aipl/test_core.py
+++ b/aipl/test_core.py
@@ -37,12 +37,6 @@ def op_uppercase(aipl, v:str) -> str:
     return v.upper()
 
 
-@pytest.fixture()
-def aipl():
-    r = AIPLInterpreter(debug=True)
-#    r.single_step = lambda *args, **kwargs: breakpoint()
-    return r
-
 def test_lowercase(aipl):
     # scalar to scalar
     # 2 rows; single column


### PR DESCRIPTION
I  added a `aipl/ops/conftest.py`, and moved the `aipl` fixture into it. This is so that the `aipl` fixture would not need to be imported into every test.

