### PR TITLE
Column refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 *.log
+aipl-cache.sqlite

--- a/aipl/table.py
+++ b/aipl/table.py
@@ -12,16 +12,10 @@ class Column:
     def __init__(self, key, name=''):
         self.name = name or key
         self.key = key
-        self.table = None  # set later by Table.add_column()
 
     @property
     def hidden(self) -> bool:
         return self.name.startswith('_')
-
-    @property
-    def last(self) -> bool:
-        'is this the last column in the table?'
-        return self is self.table.columns[-1]
 
     def get_value(self, row:Row):
         if isinstance(self.key, (list, tuple)):
@@ -97,10 +91,7 @@ class LazyRow(Mapping):
         for c in self._table.columns:
             v = c.get_value(self._row)
 
-            if c.hidden:
-                if not c.last:
-                    continue
-
+            if c.hidden and c is self._table[-1]:
 #                if not d:
 #                    return v  # simple scalar if no other named cols in the row
 

--- a/aipl/table.py
+++ b/aipl/table.py
@@ -117,7 +117,7 @@ class LazyRow(Mapping):
 
 
 class Table:
-    def __init__(self, rows:List[Mapping|LazyRow]=[], parent:'Table'=None):
+    def __init__(self, rows:List[Mapping|LazyRow]=[], parent:'Table|None'=None):
         self.rows = []  # list of dict
         self.columns = []  # list of Column
         self.parent = parent

--- a/aipl/table.py
+++ b/aipl/table.py
@@ -31,10 +31,12 @@ class Column:
     def __str__(self):
         return f'[Column {self.name}]'
 
-    @property
-    def deepname(self):
-        if self.table.rows:
-            r = self.get_value(self.table.rows[0])
+    def __repr__(self):
+        return f"<Column {self.name} {self.key}>"
+
+    def deepname(self, table):
+        if table.rows:
+            r = self.get_value(table.rows[0])
             if isinstance(r, Table):
                 return f'{self.name}:{r.deepcolnames}'
 
@@ -179,7 +181,7 @@ class Table:
 
     @property
     def deepcolnames(self) -> str:
-        return ','.join(f'{c.deepname}' for c in self.columns) or "no cols"
+        return ','.join(f'{c.deepname(self)}' for c in self.columns) or "no cols"
 
     def __getitem__(self, k:int):
         #return LazyRow(self, self.rows[k])
@@ -209,12 +211,11 @@ class Table:
     def add_new_columns(self, row:Row):
         for k in row.keys():
             if not k.startswith('__'):
-                self.add_column(Column(k, k))
+                self.add_column(Column(k))
 
     def add_column(self, col:Column):
         if col.key in self.colkeys or col.name in self.colnames:
             return
-        col.table = self
         self.columns.append(col)
 
     def get_column(self, name:str) -> Column:


### PR DESCRIPTION
Break circular dependency between Table and Column. The only times we need the .table we're calling in from the context of a table, so there's no need to store that with the column.