### PR TITLE
[cli] added --step, --dry-run, and carry parser in options AttrDict

### DIFF
--- a/aipl/db.py
+++ b/aipl/db.py
@@ -106,6 +106,9 @@ def expensive(func):
         key = f'{args} {kwargs}'
         tbl = 'cached_'+func.__name__
 
+        if db.options.dry_run:
+            return f'<{func.__name__}({key})>'
+
         ret = db.select(tbl, key=key)
         if ret:
             row = ret[-1]

--- a/aipl/interpreter.py
+++ b/aipl/interpreter.py
@@ -56,10 +56,11 @@ class AIPL(Database):
         self.next_unique_key += 1
         return f'_{r}'
 
-    def __init__(self, dbfn='aipl-output.sqlite', single_step=None, debug=True):
+    def __init__(self, dbfn='aipl-output.sqlite', single_step=None, debug=True, dry_run=False):
         super().__init__(dbfn)
         self.debug = debug
         self.single_step = single_step  # func(Table, Command) to call between steps
+        self.dry_run = dry_run
         self.globals = {}  # base context
 
     def parse_cmdline(self, line:str, linenum:int=0) -> List[Command]:

--- a/aipl/main.py
+++ b/aipl/main.py
@@ -4,8 +4,7 @@ import argparse
 
 from aipl import AIPL, Table, UserAbort
 
-
-def main():
+def parse_args(args):
     parser = argparse.ArgumentParser(description='AIPL interpreter')
     parser.add_argument('--debug', '-d', action='store_true', help='abort on exception')
     parser.add_argument('--step', action='store', default='', help='call aipl.step_<func>(cmd, input) before each step')
@@ -14,8 +13,13 @@ def main():
     parser.add_argument('--step-vd', '--vd', action='store_const', dest='step', const='vd', help='open VisiData with input before each step')
     parser.add_argument('--dry-run', '-n', action='store_true', help='do not execute @expensive operations')
     parser.add_argument('script_or_global', nargs='+', help='scripts to run, or k=v global parameters')
-    args = parser.parse_args()
+    return parser.parse_args(args)
 
+
+
+def main():
+
+    args = parse_args(None)
     global_parameters = {}
     scripts = []
 

--- a/aipl/main.py
+++ b/aipl/main.py
@@ -9,7 +9,11 @@ def main():
     parser = argparse.ArgumentParser(description='AIPL interpreter')
     parser.add_argument('--visidata', '--vd', action='store_true', help='open VisiData with input before each step')
     parser.add_argument('--debug', '-d', action='store_true', help='abort on exception')
-    parser.add_argument('--single-step', '-x', action='store_true', help='breakpoint() before each step')
+    parser.add_argument('--step', action='store', default='', help='call aipl.step_<func>(cmd, input) before each step')
+    parser.add_argument('--step-breakpoint', '-x', action='store_const', dest='step', const='breakpoint', help='breakpoint() before each step')
+    parser.add_argument('--step-rich', '-v', action='store_const', dest='step', const='rich', help='output rich table before each step')
+    parser.add_argument('--step-vd', '--vd', action='store_const', dest='step', const='vd', help='open VisiData with input before each step')
+    parser.add_argument('--dry-run', '-n', action='store_true', help='do not execute @expensive operations')
     parser.add_argument('script_or_global', nargs='+', help='scripts to run, or k=v global parameters')
     args = parser.parse_args()
 
@@ -65,6 +69,9 @@ def main():
 
     if args.debug:
         aipl.debug = True
+
+    if args.dry_run:
+        aipl.dry_run = True
 
     aipl.globals = global_parameters
 

--- a/aipl/main.py
+++ b/aipl/main.py
@@ -7,7 +7,6 @@ from aipl import AIPL, Table, UserAbort
 
 def main():
     parser = argparse.ArgumentParser(description='AIPL interpreter')
-    parser.add_argument('--visidata', '--vd', action='store_true', help='open VisiData with input before each step')
     parser.add_argument('--debug', '-d', action='store_true', help='abort on exception')
     parser.add_argument('--step', action='store', default='', help='call aipl.step_<func>(cmd, input) before each step')
     parser.add_argument('--step-breakpoint', '-x', action='store_const', dest='step', const='breakpoint', help='breakpoint() before each step')
@@ -31,7 +30,7 @@ def main():
         print('no script on stdin: nothing to do', file=sys.stderr)
         return
 
-    aipl = AIPL('aipl-cache.sqlite')
+    aipl = AIPL('aipl-cache.sqlite', **vars(args))
 
     # dup stdin/stdout if necessary
 
@@ -59,19 +58,6 @@ def main():
             aipl.stdout = sys.stdout
     else:
         aipl.stdout = sys.stdout
-
-    # parse a few options
-    if args.visidata:
-        aipl.run('!debug-vd')
-
-    if args.single_step:
-        aipl.single_step = lambda *args, **kwargs: breakpoint()
-
-    if args.debug:
-        aipl.debug = True
-
-    if args.dry_run:
-        aipl.dry_run = True
 
     aipl.globals = global_parameters
 

--- a/aipl/utils.py
+++ b/aipl/utils.py
@@ -44,6 +44,8 @@ def trynum(x:str) -> int|float|str:
 
 class AttrDict(dict):
     def __getattr__(self, k):
+        if k not in self:
+            return None
         return self[k]
 
     def __setattr__(self, k, v):

--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,8 @@
 import pytest
 
-from aipl.main import parse_args
 from aipl import AIPL
 
 @pytest.fixture()
 def aipl():
-    args = parse_args(['-d', '--script-or-global foo=bar'])
-    r = AIPL(**vars(args))
+    r = AIPL(debug=True)
     return r

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,10 @@
 import pytest
 
+from aipl.main import parse_args
 from aipl import AIPL
 
 @pytest.fixture()
 def aipl():
-    r = AIPL(debug=True)
+    args = parse_args(['-d', '--script-or-global foo=bar'])
+    r = AIPL(**vars(args))
     return r


### PR DESCRIPTION
`--dry-run` will skip the running of `@expensive` operations, returning a string `'<funcname(inputs)>'`.

I suspect where we may run into a bug is with operations that are expected to return values of a different rank. I could not figure out how to get the rankout information from within `def expensive`, and I did not have a good test available to see if that case does cause a ruckus. 

Parser args now get added to `aipl.options` which is an `AttrDict`. So, e.g., the check for dry_run is `if aipl.options.dry_run`.

`--step-*` are different flavours of step through debugging aids. e.g. `--step-rich` will print a rich table representation of what is output by each op, `--step-vd` will launch VisiData with the resulting tables loaded.