### PR TITLE
Parser strings

### DIFF
--- a/aipl/parser.py
+++ b/aipl/parser.py
@@ -2,8 +2,7 @@ from typing import List
 import textwrap
 import sys
 from dataclasses import dataclass
-import re
-
+import ast
 from lark import Lark, Transformer, Discard, Token, Tree
 
 aipl_grammar = Lark(r'''
@@ -96,7 +95,6 @@ class ToAst(Transformer):
         kwargs = {}
 
         for key, arg in arg_list:
-            arg = trynum(arg)
             if key is None:
                 args.append(arg)
             else:
@@ -127,9 +125,8 @@ class ToAst(Transformer):
     def IDENTIFIER(self, token):
         return token.value
 
-    def string(self, tree):
-        unescaped = re.sub(r'\\(.)', r'\1', re.sub(r'\\n', '\n', tree[0].value[1:-1]))
-        return unescaped
+    def ESCAPED_STRING(self, token):
+        return ast.literal_eval(token.value)
 
 def parse(program_text):
     parse_tree = aipl_grammar.parse(program_text)

--- a/aipl/parser.py
+++ b/aipl/parser.py
@@ -42,7 +42,7 @@ STRING_LINE: /^[^!#\n][^\n]*(\n|$)/m | "\n"
 
 COMMENT_LINE: /^#[^\n]*\n/m
 %ignore COMMENT_LINE
-''')
+''', propagate_positions=True)
 
 
 @dataclass

--- a/aipl/parser.py
+++ b/aipl/parser.py
@@ -32,11 +32,10 @@ arg_list: arg*
 
 arg: ws (KEY "=" literal | literal)
 
-?literal: BARE_STRING | string
-BARE_STRING: /[^ \t\n!">]\S*/
+?literal: BARE_STRING | ESCAPED_STRING
+BARE_STRING: /[^ \t\n!"'>]\S*/
 
-%import common.ESCAPED_STRING
-string: ESCAPED_STRING
+ESCAPED_STRING: /(["']).*?(?<!\\)\1/
 
 KEY: IDENTIFIER
 

--- a/aipl/test_parse.py
+++ b/aipl/test_parse.py
@@ -77,5 +77,10 @@ def test_single_quoted():
     commands = parse(r"!fn 'arg1' '\'\n'")
     assert commands[0].args == ["arg1", "'\n"]
 
+def test_numbers():
+    commands = parse("!fn 1 2.0 3.0e10 -3 -2e-7")
+    assert commands[0].args == [1, 2.0, 3.0e10, -3, -2e-7]
+
+
 def ops(commands):
     return [command.opname for command in commands]

--- a/aipl/test_parse.py
+++ b/aipl/test_parse.py
@@ -69,5 +69,9 @@ def test_nested_parse():
     assert ops(commands) == ["def", "split_join"]
     assert commands[0].kwargs == {'prompt': "!split\n\n!join"}
 
+def test_quoted():
+    commands = parse(r'!fn "arg1" "\"\n"')
+    assert commands[0].args == ["arg1", '"\n']
+
 def ops(commands):
     return [command.opname for command in commands]

--- a/aipl/test_parse.py
+++ b/aipl/test_parse.py
@@ -73,5 +73,9 @@ def test_quoted():
     commands = parse(r'!fn "arg1" "\"\n"')
     assert commands[0].args == ["arg1", '"\n']
 
+def test_single_quoted():
+    commands = parse(r"!fn 'arg1' '\'\n'")
+    assert commands[0].args == ["arg1", "'\n"]
+
 def ops(commands):
     return [command.opname for command in commands]


### PR DESCRIPTION
Add support for quoted strings in arguments.

Eg:

```
!example "quoted with spaces" '123' a='many words' "\n\t \""
```