### PR TITLE
multiple LLM clients

### DIFF
--- a/aipl/clients.py
+++ b/aipl/clients.py
@@ -77,14 +77,15 @@ class StandardClient:
             model=model
         )
         params.update(kwargs)
-        # TODO: there must be a less hacky way of doing this
+        
+        # TODO: there must be a less hacky way of doing these
         params['temperature'] = float(params['temperature'])
-        del params['client']
+        if 'client' in params:
+            del params['client']
         
         # msgs = [_parse_msg(m) for m in v.splitlines()]
         msgs = [_parse_msg(v)]
 
-        print(openai.api_base, model, msgs)
         resp = openai.ChatCompletion.create(
             messages=msgs,
             **params

--- a/aipl/clients.py
+++ b/aipl/clients.py
@@ -39,15 +39,22 @@ def _parse_msg(s:str):
         return dict(role='assistant', content=s)
     else:  # if s.startswith('@@@u'):
         return dict(role='user', content=s)
-
-class StandardClient:
-    def __init__(self, base_url=None):
-        if base_url:
-            print("using", base_url)
-            openai.api_base = base_url
     
+def count_tokens(s:str, model:str=''):
+    try:
+        import tiktoken
+        enc = tiktoken.encoding_for_model(model)
+        return len(enc.encode(s))
+    except ModuleNotFoundError as e:
+#        stderr(str(e))
+        return len(s)//4
+    except KeyError as e:
+        # just estimate
+        return len(s)//4
+
+class StandardClient:    
     def compute_cost(self, aipl, resp, model):
-        if self.type == 'openai':
+        if self.client_type == 'openai':
             used = resp['usage']['total_tokens']
             result = resp['choices'][0]['message']['content']
             cost = openai_pricing[model]*used/1000
@@ -55,24 +62,25 @@ class StandardClient:
                 aipl.cost_usd += cost
 
             stderr(f'Used {used} tokens (estimate {len(result)//4} tokens).  Cost: ${cost:.03f}')
-        elif self.type == 'custom':
+        elif self.client_type == 'custom':
             stderr('Used TODO tokens. Cost: $¯\_(ツ)_/¯')
     
     def completion(self, aipl, v:str, **kwargs) -> str:
         'Send chat messages to GPT.  Lines beginning with @@@s or @@@a are sent as system or assistant messages respectively (default user).  Passes all [named args](https://platform.openai.com/docs/guides/chat/introduction) directly to API.'
         model = kwargs.get('model') or self.default_model
-        parms = dict(
+        params = dict(
             temperature=0,
             top_p=1,
             frequency_penalty=0,
             presence_penalty=0,
+            model=model
         )
-        parms.update(kwargs)
+        params.update(kwargs)
         msgs = [_parse_msg(m) for m in v.splitlines()]
 
         resp = openai.ChatCompletion.create(
             messages=msgs,
-            **parms
+            **params
         )
         try:
             result = resp['choices'][0]['message']['content']
@@ -86,28 +94,63 @@ class GooseClient(StandardClient):
     def __init__(self):
         if 'GOOSE_AI_KEY' not in os.environ:
             raise AIPLException(f'''GOOSE_AI_KEY envvar must be set to use gooseai client type''')
-        self.type = 'gooseai'
-        self.default_model = 'gpt-neox-20b'
-        super().__init__(f'https://api.goose.ai/v1/engines/')
+        self.client_type = 'gooseai'
+        self.default_model = 'gpt-neo-20b'
+        openai.api_key = os.environ['GOOSE_AI_KEY']
+        openai.api_base = "https://api.goose.ai/v1"
+
+    def completion(self, aipl, v, **kwargs):
+        import requests
+
+        model = kwargs.get('model') or self.default_model
+        if 'GOOSE_AI_KEY' not in os.environ:
+            raise AIPLException(f'''GOOSE_AI_KEY envvar must be set for !llm to use {model}''')
+        headers = {
+            'Content-Type': 'application/json',
+            'Authorization': f'Bearer {os.environ["GOOSE_AI_KEY"]}'
+        }
+        params = dict(
+            temperature=0
+        )
+        params.update(**kwargs)
+        # TODO: GooseAI supports multiple prompt completions in parallel
+        data = {'prompt': v, **params}
+        r = requests.post(f'https://api.goose.ai/v1/engines/{model}/completions', headers=headers, json=data)
+        j = r.json()
+        if 'error' in j:
+            raise AIPLException(f'''GooseAI returned an error: {j["error"]}''')
+
+        response = j['choices'][0]['text']
+        # Only output tokens are charged
+        used = count_tokens(response, gooseai_models[model]['encoding'])
+        # GooseAI's base cost provides the first 25 tokens, then each token after is charged at the token rate
+        cost = gooseai_models[model]['pricing']['token'] * max(0, used-25) + gooseai_models[model]['pricing']['base']
+        if aipl:
+            aipl.cost_usd += cost
+        stderr(f'Used {used} tokens (estimate {len(v)//4} tokens).  Cost: ${cost:.03f}')
+        return response
 
 class OpenAIClient(StandardClient):
     def __init__(self):
         if 'OPENAI_API_KEY' not in os.environ or 'OPENAI_API_ORG' not in os.environ:
             raise AIPLException('''OPENAI_API_KEY and OPENAI_API_ORG envvars must be set for openai client type''')
-        self.type = 'openai'
+        self.client_type = 'openai'
         self.default_model = 'gpt-3.5-turbo'
-        super().__init__()
 
 class SelfHostedChatClient(StandardClient):
     def __init__(self):
         if 'LLM_CLIENT_ENDPOINT' not in os.environ:
             raise AIPLException('''LLM_CLIENT_ENDPOINT envvar must be set for selfhosted client type''')
-        self.type = 'selfhosted'
-        super().__init__(os.environ['LLM_CLIENT_ENDPOINT'])
+        openai.api_base = os.environ['LLM_CLIENT_ENDPOINT']
+        self.client_type = 'selfhosted'
+        if 'DEFAULT_SELFHOSTED_MODEL' in os.environ:
+            self.default_model = os.environ['DEFAULT_SELFHOSTED_MODEL']
 
 if __name__ == "__main__":
-    prompt = "At this rate, George RR Martin will release The Winds of Winter when"
+    max_tokens = 256
+    prompt = '''Marry, kiss, kill (and why): HAL 9000, Mr. Smith (from The Matrix), GLaDOS.
+Marry:'''
 
-    # print('openai\n', prompt, OpenAIClient().completion(None, prompt, model='gpt-3.5-turbo'))
-    # print('gooseai\n', prompt, GooseClient().completion(None, prompt))
-    print('selfhosted\n', prompt, SelfHostedChatClient().completion(None, prompt, model='Aeala/VicUnlocked-alpaca-30b-ggml/VicUnlocked-alpaca-30b-q4_0.bin', max_tokens=32))
+    print('openai\n', prompt, OpenAIClient().completion(None, prompt, max_tokens=max_tokens))
+    print('gooseai\n', prompt, GooseClient().completion(None, prompt, max_tokens=max_tokens))
+    print('selfhosted\n', prompt, SelfHostedChatClient().completion(None, prompt, max_tokens=max_tokens))

--- a/aipl/clients.py
+++ b/aipl/clients.py
@@ -1,0 +1,113 @@
+from aipl import defop, expensive, stderr, AIPLException
+import openai
+import os
+
+# from the horse's mouth, 2023-05-30
+openai_pricing = {
+    "gpt-4": 0.06,
+    "gpt-4-32k": 0.12,
+    "gpt-3.5-turbo": 0.002,
+    "gpt-3.5-turbo-16k": 0.002,
+    "text-ada-001": 0.0016,
+    "text-babbage-001": 0.0024,
+    "text-curie-001": 0.0120,
+    "text-davinci-003": 0.1200
+}
+
+# base price covers the first 25 tokens, then it's the per-token price (2023-06-06)
+gooseai_models = {
+    "fairseq-13b": {
+        "pricing": {
+            "base": 0.001250,
+            "token": 0.000036
+        },
+        "encoding": ""
+    },
+    "gpt-neo-20b": {
+        "pricing": {
+            "base": 0.002650, 
+            "token": 0.000063
+        },
+        "encoding": "gpt2"
+    }
+}
+
+def _parse_msg(s:str):
+    if s.startswith('@@@s'):
+        return dict(role='system', content=s)
+    elif s.startswith('@@@a'):
+        return dict(role='assistant', content=s)
+    else:  # if s.startswith('@@@u'):
+        return dict(role='user', content=s)
+
+class StandardClient:
+    def __init__(self, base_url=None):
+        if base_url:
+            print("using", base_url)
+            openai.api_base = base_url
+    
+    def compute_cost(self, aipl, resp, model):
+        if self.type == 'openai':
+            used = resp['usage']['total_tokens']
+            result = resp['choices'][0]['message']['content']
+            cost = openai_pricing[model]*used/1000
+            if aipl: # makes it easier to run unit tests
+                aipl.cost_usd += cost
+
+            stderr(f'Used {used} tokens (estimate {len(result)//4} tokens).  Cost: ${cost:.03f}')
+        elif self.type == 'custom':
+            stderr('Used TODO tokens. Cost: $¯\_(ツ)_/¯')
+    
+    def completion(self, aipl, v:str, **kwargs) -> str:
+        'Send chat messages to GPT.  Lines beginning with @@@s or @@@a are sent as system or assistant messages respectively (default user).  Passes all [named args](https://platform.openai.com/docs/guides/chat/introduction) directly to API.'
+        model = kwargs.get('model') or self.default_model
+        parms = dict(
+            temperature=0,
+            top_p=1,
+            frequency_penalty=0,
+            presence_penalty=0,
+        )
+        parms.update(kwargs)
+        msgs = [_parse_msg(m) for m in v.splitlines()]
+
+        resp = openai.ChatCompletion.create(
+            messages=msgs,
+            **parms
+        )
+        try:
+            result = resp['choices'][0]['message']['content']
+        except:
+            raise AIPLException(resp)
+        self.compute_cost(aipl, resp, model)
+        
+        return result
+
+class GooseClient(StandardClient):
+    def __init__(self):
+        if 'GOOSE_AI_KEY' not in os.environ:
+            raise AIPLException(f'''GOOSE_AI_KEY envvar must be set to use gooseai client type''')
+        self.type = 'gooseai'
+        self.default_model = 'gpt-neox-20b'
+        super().__init__(f'https://api.goose.ai/v1/engines/')
+
+class OpenAIClient(StandardClient):
+    def __init__(self):
+        if 'OPENAI_API_KEY' not in os.environ or 'OPENAI_API_ORG' not in os.environ:
+            raise AIPLException('''OPENAI_API_KEY and OPENAI_API_ORG envvars must be set for openai client type''')
+        self.type = 'openai'
+        self.default_model = 'gpt-3.5-turbo'
+        super().__init__()
+
+class SelfHostedChatClient(StandardClient):
+    def __init__(self):
+        if 'LLM_CLIENT_ENDPOINT' not in os.environ:
+            raise AIPLException('''LLM_CLIENT_ENDPOINT envvar must be set for selfhosted client type''')
+        self.type = 'selfhosted'
+        super().__init__(os.environ['LLM_CLIENT_ENDPOINT'])
+
+if __name__ == "__main__":
+    prompt = "At this rate, George RR Martin will release The Winds of Winter when"
+
+    # print('openai\n', prompt, OpenAIClient().completion(None, prompt, model='gpt-3.5-turbo'))
+    # print('gooseai\n', prompt, GooseClient().completion(None, prompt))
+    print('selfhosted\n', prompt, SelfHostedChatClient().completion(None, prompt, model='Aeala/VicUnlocked-alpaca-30b-ggml/VicUnlocked-alpaca-30b-q4_0.bin', max_tokens=32))

--- a/aipl/clients.py
+++ b/aipl/clients.py
@@ -62,20 +62,25 @@ class StandardClient:
                 aipl.cost_usd += cost
 
             stderr(f'Used {used} tokens (estimate {len(result)//4} tokens).  Cost: ${cost:.03f}')
-        elif self.client_type == 'custom':
+        elif self.client_type == 'selfhosted':
             stderr('Used TODO tokens. Cost: $¯\_(ツ)_/¯')
     
     def completion(self, aipl, v:str, **kwargs) -> str:
         'Send chat messages to GPT.  Lines beginning with @@@s or @@@a are sent as system or assistant messages respectively (default user).  Passes all [named args](https://platform.openai.com/docs/guides/chat/introduction) directly to API.'
         model = kwargs.get('model') or self.default_model
+        temperature = kwargs.get('temperature') or 0
         params = dict(
-            temperature=0,
+            temperature=float(temperature),
             top_p=1,
             frequency_penalty=0,
             presence_penalty=0,
             model=model
         )
         params.update(kwargs)
+        # TODO: there must be a less hacky way of doing this
+        params['temperature'] = float(params['temperature'])
+        del params['client']
+        
         # msgs = [_parse_msg(m) for m in v.splitlines()]
         msgs = [_parse_msg(v)]
 

--- a/aipl/clients.py
+++ b/aipl/clients.py
@@ -76,8 +76,10 @@ class StandardClient:
             model=model
         )
         params.update(kwargs)
-        msgs = [_parse_msg(m) for m in v.splitlines()]
+        # msgs = [_parse_msg(m) for m in v.splitlines()]
+        msgs = [_parse_msg(v)]
 
+        print(openai.api_base, model, msgs)
         resp = openai.ChatCompletion.create(
             messages=msgs,
             **params
@@ -147,9 +149,8 @@ class SelfHostedChatClient(StandardClient):
             self.default_model = os.environ['DEFAULT_SELFHOSTED_MODEL']
 
 if __name__ == "__main__":
-    max_tokens = 256
-    prompt = '''Marry, kiss, kill (and why): HAL 9000, Mr. Smith (from The Matrix), GLaDOS.
-Marry:'''
+    max_tokens = 10
+    prompt = '''A lesser-known robot character from sci-fi is'''
 
     print('openai\n', prompt, OpenAIClient().completion(None, prompt, max_tokens=max_tokens))
     print('gooseai\n', prompt, GooseClient().completion(None, prompt, max_tokens=max_tokens))

--- a/aipl/ops/llm.py
+++ b/aipl/ops/llm.py
@@ -79,16 +79,3 @@ def embedding_openai(aipl, v:str, **kwargs) -> dict:
     return dict(model=kwargs.get('model'),
                 used_tokens=used,
                 embedding=resp['data'][0]['embedding'])
- 
-def get_model_and_binary_paths() -> List[str]:
-    if 'MODELS_DIR' not in os.environ:
-        raise AIPLException('''MODELS_DIR envvar must be set for !llm-local''')
-    models_dir = Path(os.environ['MODELS_DIR'])
-    # binaries can be set per-model and globally, with preference for local
-    if os.path.isfile(models_dir/'main'):
-        inference_binary = models_dir/'main'
-    elif 'INFERENCE_BINARY' in os.environ:
-        inference_binary = Path(os.environ['INFERENCE_BINARY'])
-    else:
-        raise AIPLException('''INFERENCE_BINARY envvar must be set for !llm-local''')
-    return models_dir, inference_binary

--- a/aipl/ops/llm.py
+++ b/aipl/ops/llm.py
@@ -20,21 +20,9 @@ def _parse_msg(s:str):
     else:  # if s.startswith('@@@u'):
         return dict(role='user', content=s)
 
-def count_tokens(s:str, model:str=''):
-    try:
-        import tiktoken
-        enc = tiktoken.encoding_for_model(model)
-        return len(enc.encode(s))
-    except ModuleNotFoundError as e:
-#        stderr(str(e))
-        return len(s)//4
-    except KeyError as e:
-        # just estimate
-        return len(s)//4
-
 def op_llm_mock(aipl, v:str, **kwargs) -> str:
     model = kwargs.get('model')
-    used = count_tokens(v, model=model)
+    used = clients.count_tokens(v, model=model)
     cost = clients.openai_pricing[model]*used/1000
     aipl.cost_usd += cost
     return f'<llm {model} answer>'

--- a/aipl/ops/llm.py
+++ b/aipl/ops/llm.py
@@ -9,7 +9,7 @@ import os
 import subprocess
 from pathlib import Path
 
-from aipl import defop, expensive, stderr, AIPLException
+from aipl import defop, expensive, stderr, AIPLException, clients
 
 
 def _parse_msg(s:str):
@@ -19,37 +19,6 @@ def _parse_msg(s:str):
         return dict(role='assistant', content=s)
     else:  # if s.startswith('@@@u'):
         return dict(role='user', content=s)
-
-
-# from the horse's mouth, 2023-05-30
-openai_pricing = {
-    "gpt-4": 0.06,
-    "gpt-4-32k": 0.12,
-    "gpt-3.5-turbo": 0.002,
-    "gpt-3.5-turbo-16k": 0.002,
-    "text-ada-001": 0.0016,
-    "text-babbage-001": 0.0024,
-    "text-curie-001": 0.0120,
-    "text-davinci-003": 0.1200
-}
-
-# base price covers the first 25 tokens, then it's the per-token price (2023-06-06)
-gooseai_models = {
-    "fairseq-13b": {
-        "pricing": {
-            "base": 0.001250,
-            "token": 0.000036
-        },
-        "encoding": ""
-    },
-    "gpt-neo-20b": {
-        "pricing": {
-            "base": 0.002650, 
-            "token": 0.000063
-        },
-        "encoding": "gpt2"
-    }
-}
 
 def count_tokens(s:str, model:str=''):
     try:
@@ -66,7 +35,7 @@ def count_tokens(s:str, model:str=''):
 def op_llm_mock(aipl, v:str, **kwargs) -> str:
     model = kwargs.get('model')
     used = count_tokens(v, model=model)
-    cost = openai_pricing[model]*used/1000
+    cost = clients.openai_pricing[model]*used/1000
     aipl.cost_usd += cost
     return f'<llm {model} answer>'
 
@@ -75,81 +44,32 @@ def op_llm_mock(aipl, v:str, **kwargs) -> str:
 def route_llm_query(aipl, v:str, **kwargs) -> str:
     'Send chat messages to `model` (default: gpt-3.5-turbo).  Lines beginning with @@@s or @@@a are sent as system or assistant messages respectively (default user).  Passes all named args directly to API.'
     model = kwargs.get('model')
-    if model is None:
-        kwargs['model'] = 'gpt-3.5-turbo'
-        return completion_openai(aipl, v, **kwargs)
-    if model in gooseai_models:
-        return completion_gooseai(aipl, v, **kwargs)
-    elif model in openai_pricing:
-        return completion_openai(aipl, v, **kwargs)
+    client_str = kwargs.get('client')
+    if client_str is None:
+        if os.environ['LLM_CLIENT_ENDPOINT']:
+            client = clients.StandardClient(os.environ['LLM_CLIENT_ENDPOINT'])
+        else:
+            client = clients.StandardClient()
     else:
-        raise AIPLException(f"{model} not found!")
+        if client_str == 'custom':
+            client = clients.StandardClient(os.environ['LLM_CLIENT_ENDPOINT'])
+        elif client_str == 'openai':
+            client = clients.StandardClient()
+        elif client_str == 'gooseai':
+            client = clients.GooseClient()
+        else:
+            raise AIPLException(f"client '{client_str}' not recognized")
 
-def completion_openai(aipl, v:str, **kwargs) -> str:
-    'Send chat messages to GPT.  Lines beginning with @@@s or @@@a are sent as system or assistant messages respectively (default user).  Passes all [named args](https://platform.openai.com/docs/guides/chat/introduction) directly to API.'
-    import openai
-    model = kwargs.get('model')
-    parms = dict(
-        temperature=0,
-        top_p=1,
-        frequency_penalty=0,
-        presence_penalty=0,
-    )
-    parms.update(kwargs)
-    msgs = [_parse_msg(m) for m in v.splitlines()]
-
-    if 'OPENAI_API_KEY' not in os.environ or 'OPENAI_API_ORG' not in os.environ:
-        raise AIPLException('''OPENAI_API_KEY and OPENAI_API_ORG envvars must be set for !llm''')
-
-    resp = openai.ChatCompletion.create(
-        messages=msgs,
-        **parms
-    )
-    used = resp['usage']['total_tokens']
-    result = resp['choices'][0]['message']['content']
-
-    cost = openai_pricing[model]*used/1000
-    aipl.cost_usd += cost
-    stderr(f'Used {used} tokens (estimate {len(v)//4} tokens).  Cost: ${cost:.03f}')
-    return result
-
-def completion_gooseai(aipl, v:str, **kwargs) -> str:
-    import requests
-    model = kwargs.get('model')
-    if 'GOOSE_AI_KEY' not in os.environ:
-        raise AIPLException(f'''GOOSE_AI_KEY envvar must be set for !llm to use {model}''')
-    headers = {
-        'Content-Type': 'application/json',
-        'Authorization': f'Bearer {os.environ["GOOSE_AI_KEY"]}'
-    }
-    params = dict(
-        temperature=0
-    )
-    params.update(**kwargs)
-    # TODO: GooseAI supports multiple prompt completions in parallel
-    data = {'prompt': v, **params}
-    r = requests.post(f'https://api.goose.ai/v1/engines/{model}/completions', headers=headers, json=data)
-    j = r.json()
-    if 'error' in j:
-        raise AIPLException(f'''GooseAI returned an error: {j["error"]}''')
-
-    response = j['choices'][0]['text']
-    # Only output tokens are charged
-    used = count_tokens(response, gooseai_models[model]['encoding'])
-    # GooseAI's base cost provides the first 25 tokens, then each token after is charged at the token rate
-    cost = gooseai_models[model]['pricing']['token'] * max(0, used-25) + gooseai_models[model]['pricing']['base']
-    aipl.cost_usd += cost
-    stderr(f'Used {used} tokens (estimate {len(v)//4} tokens).  Cost: ${cost:.03f}')
-    return response
+    return client.completion(aipl, v, **kwargs)
 
 @defop('llm-embedding', 0, 0.5)
 @expensive()
 def route_llm_embedding_query(aipl, v:str, **kwargs) -> str:
     'Get a [text embedding](https://platform.openai.com/docs/guides/embeddings/what-are-embeddings) for a string from `model`: a measure of text-relatedness, to be used with e.g. !cluster.'
     model = kwargs.get('model')
-    if model in gooseai_models:
+    if model in clients.gooseai_models:
         raise AIPLException("GooseAI embeddings not yet supported")
-    elif model in openai_pricing:
+    elif model in clients.openai_pricing:
         return embedding_openai(aipl, v, **kwargs)
     else:
         raise AIPLException(f"{model} not found!")
@@ -185,53 +105,3 @@ def get_model_and_binary_paths() -> List[str]:
     else:
         raise AIPLException('''INFERENCE_BINARY envvar must be set for !llm-local''')
     return models_dir, inference_binary
-
-@defop('llm-local', 0, 0)
-@expensive(op_llm_mock)
-def completion_local(aipl, v:str, **kwargs) -> str:
-    models_dir, inference_binary = get_model_and_binary_paths()
-
-    model = kwargs.get('model')
-    if not model:
-        raise AIPLException('''local model must be defined''')
-    if 'GPU_LAYERS' in os.environ and int(os.environ['GPU_LAYERS']) > 0:
-        return completion_local_gpu(aipl, v, **kwargs)
-    max_tokens = kwargs.get('max_tokens') or '-1'    
-    stderr(model, '\n>>>\n' + v, end='')
-    res = subprocess.run([
-            inference_binary, 
-            '--model', models_dir/model, 
-            '--n_predict', str(max_tokens), 
-            '--prompt', v,
-            '--temp', '0'
-        ],
-        capture_output=True)
-    if len(res.stdout) == 0:
-        raise Exception(res.stderr.decode())
-    output_without_prompt = res.stdout.decode().replace(v, '', 1)
-    stderr(output_without_prompt, '\n<<<')
-    return output_without_prompt
-
-def completion_local_gpu(aipl, v:str, **kwargs) -> str:
-    models_dir, inference_binary = get_model_and_binary_paths()
-
-    model = kwargs.get('model')
-    layers = os.environ['GPU_LAYERS']
-    max_tokens = kwargs.get('max_tokens') or '-1' 
-    stderr(model, f"(layers: {layers})", '\n>>>\n' + v, end='')
-    res = subprocess.run([
-            inference_binary,
-            '--model', models_dir/model,
-            '--n_predict', str(max_tokens),
-            '--prompt', v,
-            '--temp', '0',
-            '--gpu-layers', layers,
-            '--threads', '14',
-            '--batch-size', '512'
-        ],
-        capture_output=True)
-    if len(res.stdout) == 0:
-        raise Exception(res.stderr.decode())
-    output_without_prompt = res.stdout.decode().replace(v, '', 1)
-    stderr(output_without_prompt, '\n<<<')
-    return output_without_prompt

--- a/aipl/ops/llm.py
+++ b/aipl/ops/llm.py
@@ -33,7 +33,7 @@ def route_llm_query(aipl, v:str, **kwargs) -> str:
     'Send chat messages to `model` (default: gpt-3.5-turbo).  Lines beginning with @@@s or @@@a are sent as system or assistant messages respectively (default user).  Passes all named args directly to API.'
     client_str = kwargs.get('client')
     if client_str is None:
-        if os.environ['LLM_CLIENT_ENDPOINT']:
+        if 'LLM_CLIENT_ENDPOINT' in os.environ:
             client = clients.SelfHostedChatClient()
         else:
             client = clients.OpenAIClient()

--- a/aipl/ops/llm.py
+++ b/aipl/ops/llm.py
@@ -31,18 +31,17 @@ def op_llm_mock(aipl, v:str, **kwargs) -> str:
 @expensive(op_llm_mock)
 def route_llm_query(aipl, v:str, **kwargs) -> str:
     'Send chat messages to `model` (default: gpt-3.5-turbo).  Lines beginning with @@@s or @@@a are sent as system or assistant messages respectively (default user).  Passes all named args directly to API.'
-    model = kwargs.get('model')
     client_str = kwargs.get('client')
     if client_str is None:
         if os.environ['LLM_CLIENT_ENDPOINT']:
-            client = clients.StandardClient(os.environ['LLM_CLIENT_ENDPOINT'])
+            client = clients.SelfHostedChatClient()
         else:
-            client = clients.StandardClient()
+            client = clients.OpenAIClient()
     else:
-        if client_str == 'custom':
-            client = clients.StandardClient(os.environ['LLM_CLIENT_ENDPOINT'])
+        if client_str == 'selfhosted':
+            client = clients.SelfHostedChatClient()
         elif client_str == 'openai':
-            client = clients.StandardClient()
+            client = clients.OpenAIClient()
         elif client_str == 'gooseai':
             client = clients.GooseClient()
         else:


### PR DESCRIPTION
This generalizes to allow different clients that can do LLM inference.
- removes AIPL's dependence on llama.cpp
- new assumption is that everything will by default be over HTTP
- adds the idea of a client (similar to [HELM](https://github.com/stanford-crfm/helm/blob/main/src/helm/proxy/clients/openai_client.py)) which handles the inference
- adds clients for OpenAI, GooseAI, and a custom HTTP server that is compatible with the openai library