### PR TITLE
Add support for Azure, OpenAI, Palm, Anthropic, Cohere Models - using litellm

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 openai
+litellm==0.1.226
 scikit-learn
 numpy
 trafilatura  # for html extraction


### PR DESCRIPTION
I'm the maintainer of litellm https://github.com/BerriAI/litellm - a simple & light package to call OpenAI, Azure, Cohere, Anthropic API Endpoints

This PR adds support for models from all the above mentioned providers. 
I created a liteLLM client in clients.py

Here's a sample of how it's used:

```
from litellm import completion

## set ENV variables
# ENV variables can be set in .env file, too. Example in .env.example
os.environ["OPENAI_API_KEY"] = "openai key"
os.environ["COHERE_API_KEY"] = "cohere key"

messages = [{ "content": "Hello, how are you?","role": "user"}]

# openai call
response = completion(model="gpt-3.5-turbo", messages=messages)

# cohere call
response = completion("command-nightly", messages)

# anthropic call
response = completion(model="claude-instant-1", messages=messages)
```