### PR TITLE
When running as main, handle leading python

### DIFF
--- a/aipl/parser.py
+++ b/aipl/parser.py
@@ -179,7 +179,9 @@ def clean_to_id(s:str) -> str:
 if __name__ == '__main__':
     for file in sys.argv[1:]:
         print("Parsing: ", file)
-        parse_tree = aipl_grammar.parse(open(file).read())
+        # prepend `!!python` to the input to correctly handle any leading python code
+        # see also: AIPL.run() method in interpreter.py
+        parse_tree = aipl_grammar.parse('!!python\n' + open(file).read())
         print("Parse tree: ", parse_tree.pretty())
         for command in ToAst().transform(parse_tree):
             print(command)


### PR DESCRIPTION
Previously, calling the parser directly on a file with leading python would break, eg:

```
$python aipl/parser.py examples/hanukkah-of-data-5783.aipl
Parsing:  examples/hanukkah-of-data-5783.aipl
Traceback (most recent call last):
...
lark.exceptions.UnexpectedCharacters: No terminal matches '@' in the current parser context, at line 1 col 1

@defop('sql', 0, 1.5)
^
Expected one of: 
        * _EMPTY_LINE
        * __ANON_0
```

Prepending an explicit `!!python\n` to the input, as `AIPL.run()` does, handles it correctly.